### PR TITLE
Hardcoded the python version to be 3.8.*. Added .git to dockerignore.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .venv
 src/data
 .mypy_cache
+.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "3.8.*"
 Flask = "^1.1.2"
 bokeh = "^2.2.3"
 pandas = "^1.2.2"


### PR DESCRIPTION
When running `poetry install` with a Python version other than `3.8.*` will now throw the following error:

```
The currently activated Python version 3.9.2 is not supported by the project (3.8.*).
Trying to find and use a compatible version.

  NoCompatiblePythonVersionFound

  Poetry was unable to find a compatible version. If you have one, you can explicitly use it via the "env use" command.

  at /opt/poetry/lib/poetry/utils/env.py:735 in create_venv
       731│                     python_minor = ".".join(python_patch.split(".")[:2])
       732│                     break
       733│
       734│             if not executable:
    →  735│                 raise NoCompatiblePythonVersionFound(
       736│                     self._poetry.package.python_versions
       737│                 )
       738│
       739│         if root_venv:
The command '/bin/sh -c poetry install' returned a non-zero code: 1
```