### PR TITLE
Added link size based on post count

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,4 +1,4 @@
 FLASK_APP=main.py
 FLASK_ENV=development
 BODY_DATA_PATH=src/data/reddit_hyperlinks_body.parquet.gzip
-TITLE_DATA_PATH=src/data/reddit_hyperlinks_title.csv
+NETWORK_BODY_DATA_PATH=src/data/network_reddit_hyperlinks_body.parquet.gzip

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,5 +1,7 @@
 from flask import Blueprint
+from src.api.helpers.body_data_transformer import BodyDataTransformer
 
 bp = Blueprint("api", __name__)
+BodyDataTransformer().transform()
 
 from src.api import routes

--- a/src/api/helpers/body_data_transformer.py
+++ b/src/api/helpers/body_data_transformer.py
@@ -1,0 +1,40 @@
+import math
+import os
+import pandas as pd
+
+
+class BodyDataTransformer:
+    """Transforms the body data into data that the network reads."""
+
+    OUTPUT_FILE_NAME = os.getenv("NETWORK_BODY_DATA_PATH")
+    BODY_DATA_PATH = os.getenv("BODY_DATA_PATH")
+
+    def __init__(self) -> None:
+        self.data = pd.read_parquet(self.BODY_DATA_PATH, engine="pyarrow")
+
+    def transform(self):
+        print("Transforming data to network data..")
+        result = self._groupby()
+        result["normalized_count"] = self._normalize_count(result)
+
+        result.to_parquet(self.OUTPUT_FILE_NAME, engine="pyarrow")
+        print("Transform successfull!")
+
+    def _groupby(self):
+        return (
+            self.data.groupby(["SOURCE_SUBREDDIT", "TARGET_SUBREDDIT"])
+            .size()
+            .reset_index()
+            .rename(columns={0: "count"})
+            .sort_values("count", ascending=False)
+        )
+
+    def _normalize_count(self, data: pd.DataFrame) -> pd.Series:
+        result = data.apply(lambda row: self._normalize(row["count"]), axis=1)
+        return round(result, 2)
+
+    @staticmethod
+    def _normalize(value: float) -> float:
+        result = math.log(value)
+        result += 0.25
+        return result

--- a/src/api/helpers/network_graph_helper.py
+++ b/src/api/helpers/network_graph_helper.py
@@ -10,9 +10,7 @@ class NetworkGraphHelper:
     @staticmethod
     def to_network_graph(data: pd.DataFrame) -> dict:
         def to_links(data):
-            return data[
-                ["SOURCE_SUBREDDIT", "TARGET_SUBREDDIT", "count"]
-            ].values.tolist()
+            return data.values.tolist()
 
         def to_nodes_with_cluster():
             """Add cluster data to nodes.

--- a/src/client/static/app_container.js
+++ b/src/client/static/app_container.js
@@ -3,8 +3,8 @@ Vue.component("app-container", {
   data: function () {
     return {
       networkData: null, // The raw data used in the graph-network component
-      numberOfLinks: 200,
-      numberOfLinksSliderValue: 200,
+      numberOfLinks: 2000,
+      numberOfLinksSliderValue: 2000,
       isLoadingData: false, // Whether network data is currently being loaded
       selectedSourceSubreddit: null, // The selected source subreddit after going through validation
       selectedTargetSubreddit: null, // The selected target subreddit after going through validation
@@ -33,23 +33,23 @@ Vue.component("app-container", {
     },
   },
   watch: {
-    selectedSourceSubreddit () {
+    selectedSourceSubreddit() {
       if (!this.selectedSourceSubreddit && !this.selectedTargetSubreddit) {
         this.fetchData()
       }
     },
-    selectedTargetSubreddit () {
+    selectedTargetSubreddit() {
       if (!this.selectedSourceSubreddit && !this.selectedTargetSubreddit) {
         this.fetchData()
       }
     },
     sourceSubredditQuery: function (query) {
-      if (query != null) { 
+      if (query != null) {
         this.handleSubredditQueryChange(type = "source")
       }
     },
     targetSubredditQuery: function (query) {
-      if (query != null) { 
+      if (query != null) {
         this.handleSubredditQueryChange(type = "target")
       }
     },

--- a/src/client/static/graph_network.js
+++ b/src/client/static/graph_network.js
@@ -117,12 +117,11 @@ Vue.component('graph-network', {
             this.d3Context.clearRect(0, 0, this.width, this.height);
         },
         drawLinks(links) {
-            const getColor = () => "#bdbdbd";
-            const getWidth = () => this.d3LinkWidth;
+            const getColor = () => "#0000001a";
+            const getWidth = (d) => d.normalizedCount
             const getCurvature = () => .3;
 
             links.forEach(calcLinkControlPoints); // calculate curvature control points for all visible links
-
             // Bundle strokes per unique color/width for performance optimization
             const linksPerColor = indexBy(links, [getColor, getWidth]);
 
@@ -536,7 +535,7 @@ Vue.component('graph-network', {
         },
         setDataFromNetworkData() {
             // Transform the rows from being arrays of values to objects.
-            this.links = this.networkData.links.map(d => ({ source: d[0], target: d[1], value: d[2] }))
+            this.links = this.networkData.links.map(d => ({ source: d[0], target: d[1], count: d[2], normalizedCount: d[3] }))
             this.nodes = this.networkData.nodes.map(d => ({ id: d[0], type: d[1], group: d[2], collapsed: this.collapseAll }))
         },
         init() {
@@ -555,7 +554,7 @@ Vue.component('graph-network', {
             // Performance optimizations
             this.d3Context.imageSmoothingEnabled = false
             this.d3Context.translate(0.5, 0.5)
-            this.d3Context.alpha = false
+            this.d3Context.alpha = true
 
             // Force simulation
             this.initForceSimulation()


### PR DESCRIPTION
❗ **Important**: This branch requires you to set a new `.env` variable `NETWORK_BODY_DATA_PATH`.

```ini
FLASK_APP=main.py
FLASK_ENV=development
BODY_DATA_PATH=src/data/reddit_hyperlinks_body_updated.parquet.gzip
NETWORK_BODY_DATA_PATH=src/data/network_reddit_hyperlinks_body.parquet.gzip
```

## Trello card

- [As a user, I would like to see edges in the network to be thicker, the more posts exists towards a specific subreddit, so that I can see which subreddits have a more intense post history between each other.](https://trello.com/c/f2837itQ/47-as-a-user-i-would-like-to-see-edges-in-the-network-to-be-thicker-the-more-posts-exists-towards-a-specific-subreddit-so-that-i-ca)

## Features

- Added variable link size in the network based on (normalized) post count.
- Added link alpha/transparency so that links are easier to see in cluttered environments.
- Added module `body_data_transformer.py` that creates a network data parquet file when the server is initially started.
  - This file contains the links with their post `count` and a `normalized_count`.

![image](https://user-images.githubusercontent.com/15928604/112751718-b3a6fe00-8fcf-11eb-9249-cbac60260c0b.png)
