### PR TITLE
Feature/network variable node size

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -3,6 +3,3 @@ FLASK_ENV=development
 
 # The path to the data that has been preprocessed
 BODY_DATA_PATH=src/data/reddit_hyperlinks_body_updated.parquet.gzip
-
-# This data is automatically generated based on BODY_DATA_PATH upon running the app; you can keep this the default.
-NETWORK_BODY_DATA_PATH=src/data/network_reddit_hyperlinks_body.parquet.gzip

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,7 +1,9 @@
 from flask import Blueprint
 from src.api.helpers.body_data_transformer import BodyDataTransformer
+from src.api.helpers.node_attribute_transformer import NodeAttributeTransformer
 
 bp = Blueprint("api", __name__)
 BodyDataTransformer().transform()
+NodeAttributeTransformer().transform()
 
 from src.api import routes

--- a/src/api/helpers/body_data_transformer.py
+++ b/src/api/helpers/body_data_transformer.py
@@ -6,7 +6,7 @@ import pandas as pd
 class BodyDataTransformer:
     """Transforms the body data into data that the network reads."""
 
-    OUTPUT_FILE_NAME = os.getenv("NETWORK_BODY_DATA_PATH")
+    OUTPUT_FILE_NAME = "src/data/network_data.parquet.gzip"
     BODY_DATA_PATH = os.getenv("BODY_DATA_PATH")
 
     def __init__(self) -> None:

--- a/src/api/helpers/network_graph_helper.py
+++ b/src/api/helpers/network_graph_helper.py
@@ -1,4 +1,5 @@
 import collections
+from src.api.helpers.node_attribute_transformer import NodeAttributeTransformer
 
 import networkx as nx
 import pandas as pd
@@ -7,8 +8,21 @@ import pandas as pd
 class NetworkGraphHelper:
     """This class helps to with data formatting for the network graph."""
 
-    @staticmethod
-    def to_network_graph(data: pd.DataFrame) -> dict:
+    node_attribute_data = pd.read_parquet(
+        NodeAttributeTransformer.OUTPUT_FILE_NAME, engine="pyarrow"
+    )
+
+    def _merge_attributes(self, nodes):
+        nodes_df = pd.DataFrame(nodes)
+        return (
+            pd.merge(
+                nodes_df, self.node_attribute_data, left_on=0, right_on="subreddit"
+            )
+            .drop(columns="subreddit")
+            .values.tolist()
+        )
+
+    def to_network_graph(self, data: pd.DataFrame) -> dict:
         def to_links(data):
             return data.values.tolist()
 
@@ -51,5 +65,6 @@ class NetworkGraphHelper:
             return result
 
         nodes = to_nodes_with_cluster()
+        nodes = self._merge_attributes(nodes)
         links = to_links(data)
         return {"nodes": nodes, "links": links}

--- a/src/api/helpers/network_graph_helper.py
+++ b/src/api/helpers/network_graph_helper.py
@@ -13,7 +13,7 @@ class NetworkGraphHelper:
     )
 
     def _merge_attributes(self, nodes):
-        nodes_df = pd.DataFrame(nodes)
+        nodes_df = pd.DataFrame(nodes, dtype=object)
         return (
             pd.merge(
                 nodes_df, self.node_attribute_data, left_on=0, right_on="subreddit"

--- a/src/api/helpers/node_attribute_transformer.py
+++ b/src/api/helpers/node_attribute_transformer.py
@@ -1,0 +1,23 @@
+import os
+import pandas as pd
+
+
+class NodeAttributeTransformer:
+    """Transforms the body data into data that the network reads."""
+
+    OUTPUT_FILE_NAME = "src/data/node_attributes.parquet.gzip"
+    BODY_DATA_PATH = os.getenv("BODY_DATA_PATH")
+
+    def __init__(self) -> None:
+        self.data = pd.read_parquet(self.BODY_DATA_PATH, engine="pyarrow")
+
+    def transform(self):
+        print("Transforming data to node attribute data..")
+        source_count = self.data.groupby("SOURCE_SUBREDDIT").size().reset_index().rename(columns={0: "count", "SOURCE_SUBREDDIT": "subreddit"})
+        target_count = self.data.groupby("TARGET_SUBREDDIT").size().reset_index().rename(columns={0: "count", "TARGET_SUBREDDIT": "subreddit"})
+
+        result = pd.merge(source_count, target_count, on="subreddit").set_index("subreddit")
+        result = result.sum(axis=1).reset_index().rename(columns={0: "total_posts"})
+        result.to_parquet(self.OUTPUT_FILE_NAME, engine="pyarrow")
+        print("Transform successfull!")
+

--- a/src/api/helpers/node_attribute_transformer.py
+++ b/src/api/helpers/node_attribute_transformer.py
@@ -16,7 +16,7 @@ class NodeAttributeTransformer:
         source_count = self.data.groupby("SOURCE_SUBREDDIT").size().reset_index().rename(columns={0: "count", "SOURCE_SUBREDDIT": "subreddit"})
         target_count = self.data.groupby("TARGET_SUBREDDIT").size().reset_index().rename(columns={0: "count", "TARGET_SUBREDDIT": "subreddit"})
 
-        result = pd.merge(source_count, target_count, on="subreddit").set_index("subreddit")
+        result = pd.merge(source_count, target_count, on="subreddit", how="outer").set_index("subreddit")
         result = result.sum(axis=1).reset_index().rename(columns={0: "total_posts"})
         result.to_parquet(self.OUTPUT_FILE_NAME, engine="pyarrow")
         print("Transform successfull!")

--- a/src/api/model/body_model.py
+++ b/src/api/model/body_model.py
@@ -1,11 +1,11 @@
 import os
-
-from numpy.lib.utils import source
-from src.api.helpers.network_graph_helper import NetworkGraphHelper
 from typing import Optional
 
 import networkx as nx
 import pandas as pd
+from numpy.lib.utils import source
+from src.api.helpers.body_data_transformer import BodyDataTransformer
+from src.api.helpers.network_graph_helper import NetworkGraphHelper
 
 
 class BodyModel:
@@ -14,7 +14,7 @@ class BodyModel:
     This returns a reference to the singleton object.
     """
     BODY_DATA_PATH = os.getenv("BODY_DATA_PATH")
-    NETWORK_BODY_DATA_PATH = os.getenv("NETWORK_BODY_DATA_PATH")
+    NETWORK_BODY_DATA_PATH = BodyDataTransformer.OUTPUT_FILE_NAME
     AGGREGATE_COLUMNS = [
         'Automated readability index',
         'Average word length',

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -15,6 +15,7 @@ from src.api import bp
 from src.api.helpers.network_graph_helper import NetworkGraphHelper
 from src.api.model.body_model import BodyModel
 
+network_graph_helper = NetworkGraphHelper()
 
 @bp.errorhandler(404)
 def resource_not_found(e):
@@ -152,7 +153,7 @@ def network():
 			abort(404, description="Resource not found")
 	else:
 		data = BodyModel.get_instance().get_network_data(n_links=n_links)
-	network_graph = NetworkGraphHelper.to_network_graph(data)
+	network_graph = network_graph_helper.to_network_graph(data)
 	return jsonify(network_graph)
 
 @bp.route("/properties-radar")

--- a/src/client/static/graph_network.js
+++ b/src/client/static/graph_network.js
@@ -24,7 +24,6 @@ Vue.component('graph-network', {
             d3Context: null,
             d3Transform: null,
             d3Scale: d3.scaleOrdinal(d3.schemeCategory10),
-            d3NodeRadius: 5,
             d3LinkWidth: 1,
             ...d3ForceInitialState(),
             selectedNodeId: null,
@@ -122,7 +121,7 @@ Vue.component('graph-network', {
             this.drawArrows(linksToDraw)
             // Draw the nodes
             const nodesToDraw = this.getNodesToDraw
-            nodesToDraw.forEach(node => this.drawNode(node, this.d3NodeRadius))
+            nodesToDraw.forEach(node => this.drawNode(node))
             this.drawSelectedNode()
             this.drawSelectedSubreddits()
 
@@ -363,7 +362,7 @@ Vue.component('graph-network', {
         drawSelectedSubreddits() {
             const drawSelection = (node, color) => {
                 this.d3Context.beginPath();
-                this.drawNode(node, this.d3NodeRadius * 2)
+                this.drawNode(node)
                 this.d3Context.fill();
                 this.d3Context.strokeStyle = color;
                 this.d3Context.lineWidth = .7;
@@ -387,7 +386,7 @@ Vue.component('graph-network', {
                 const node = this.getNodeById(this.selectedNodeId)
                 if (node) {
                     this.d3Context.beginPath();
-                    this.drawNode(node, this.d3NodeRadius)
+                    this.drawNode(node)
                     this.d3Context.fill();
                     this.d3Context.strokeStyle = "orange";
                     this.d3Context.lineWidth = 1;


### PR DESCRIPTION
# Trello
<img src="https://user-images.githubusercontent.com/15928604/112893120-88f59c00-90da-11eb-8f9d-82f72b5cfb39.png" width=250>

The last card is essentially done, as the size of a node tells something about the size of its subgraph.

# Features

- Added variable node size, based on post count property
- Tweaked styling
  - Node name is always white with a black outline
  - Nodes are now also highlighted, when links are highlighted
  - Child nodes have more white in their center, might change later when doing proper styling
- Fixed nodes sometimes not registering being clicked, by taking into account their variable size, instead of a fixed node radius
- Removed `.env` var

# Screenshot
<img src="https://user-images.githubusercontent.com/15928604/112892900-37e5a800-90da-11eb-80d4-d40306599b62.png" width=400>

## Restyled node name text for readability

<img src="https://user-images.githubusercontent.com/15928604/112893690-4d0f0680-90db-11eb-8eb3-a02f5cc5e44d.png" width=600>
